### PR TITLE
Fix symbol visibility issues with CMake version update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.4)
 include(version.cmake)
 include("standard/Standard.cmake")
 standard_project(LeapIPC VERSION ${LeapIPC_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.3)
 include(version.cmake)
 include("standard/Standard.cmake")
 standard_project(LeapIPC VERSION ${LeapIPC_VERSION})


### PR DESCRIPTION
On OS X, I was seeing these loud warnings, basically saying we had the wrong symbol visibility for `libLeapIPC.a` 

```
CMake Warning (dev) at src/leapipc/testing/CMakeLists.txt:13 (add_executable):
  Policy CMP0063 is not set: Honor visibility properties for all target
  types.  Run "cmake --help-policy CMP0063" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  Target "LeapIPCTest" of type "EXECUTABLE" has the following visibility
  properties set for CXX:

    CXX_VISIBILITY_PRESET
    VISIBILITY_INLINES_HIDDEN
...
ld: warning: direct access in function 'autowiring::signal<void (autowiring::CoreObjectDescriptor const&)>::leave() const' from file '/opt/local/Libraries/autowiring-1.0.3/lib/libAutowiring.a(CoreContext.cpp.o)' to global weak symbol 
```

It turns out CMP0063 is default to `OLD` for CMake 3.0, but `NEW` on CMake 3.3 and above, which is why we weren't seeing the same problem with LeapHTTP.
