### PR TITLE
Correctly handle connection lost

### DIFF
--- a/src/leapipc/IPCEndpoint.cpp
+++ b/src/leapipc/IPCEndpoint.cpp
@@ -411,6 +411,10 @@ const IPCEndpoint::Header& IPCEndpoint::ReadMessageHeader(void) {
     throw std::runtime_error("Attempted to read a message header when payload bytes remain");
 
   auto ncb = ReadRaw(&m_lastHeader, sizeof(m_lastHeader));
+  if (ncb <= 0) {
+    // we are being closed
+    Close(Reason::ConnectionLost);
+  }
   if (sizeof(m_lastHeader) == ncb) {
     m_nRemain = m_lastHeader.PayloadSize();
     if (m_lastHeader.magic1 != 0x64 || m_lastHeader.magic2 != 0x37)

--- a/src/leapipc/IPCEndpoint.cpp
+++ b/src/leapipc/IPCEndpoint.cpp
@@ -413,7 +413,7 @@ const IPCEndpoint::Header& IPCEndpoint::ReadMessageHeader(void) {
   auto ncb = ReadRaw(&m_lastHeader, sizeof(m_lastHeader));
   if (ncb <= 0) {
     // we are being closed
-    Close(Reason::ConnectionLost);
+    Close(Reason::ReadFailure);
   }
   if (sizeof(m_lastHeader) == ncb) {
     m_nRemain = m_lastHeader.PayloadSize();
@@ -443,6 +443,6 @@ std::streamsize IPCEndpoint::ReadPayload(void* pBuf, size_t ncb) {
   if (0 < retVal)
     m_nRemain -= (size_t)retVal;
   else
-    Close(Reason::ConnectionLost);
+    Close(Reason::ReadFailure);
   return retVal;
 }

--- a/src/leapipc/IPCEndpoint.cpp
+++ b/src/leapipc/IPCEndpoint.cpp
@@ -442,5 +442,7 @@ std::streamsize IPCEndpoint::ReadPayload(void* pBuf, size_t ncb) {
   auto retVal = ReadRaw(pBuf, ncb);
   if (0 < retVal)
     m_nRemain -= (size_t)retVal;
+  else
+    Close(Reason::ConnectionLost);
   return retVal;
 }

--- a/src/leapipc/IPCEndpoint.cpp
+++ b/src/leapipc/IPCEndpoint.cpp
@@ -420,7 +420,7 @@ const IPCEndpoint::Header& IPCEndpoint::ReadMessageHeader(void) {
     m_lastHeader = {};
 
   if(sizeof(m_lastHeader) < m_lastHeader.Size()) {
-    auto nSkip = sizeof(m_lastHeader) - m_lastHeader.Size();
+    auto nSkip = m_lastHeader.Size() - sizeof(m_lastHeader);
     if(m_drain.size() < nSkip)
       m_drain.resize(nSkip);
     ReadRawN(m_drain.data(), nSkip);

--- a/src/leapipc/IPCEndpoint.h
+++ b/src/leapipc/IPCEndpoint.h
@@ -199,6 +199,7 @@ public:
 
 protected:
   // Low-level raw read/write functions (platform specific)
+  // This is a blocking call
   virtual std::streamsize ReadRaw(void* buffer, std::streamsize size) = 0;
   virtual bool WriteRaw(const void* pBuf, std::streamsize nBytes) = 0;
 


### PR DESCRIPTION
If `ReadRaw` returns 0 or -1, we know the connection is lost. Close it correctly.