### PR TITLE
Fix flush after write

### DIFF
--- a/src/leapipc/IPCFileEndpoint.cpp
+++ b/src/leapipc/IPCFileEndpoint.cpp
@@ -31,6 +31,7 @@ std::streamsize IPCFileEndpoint::ReadRaw(void* buffer, std::streamsize size) {
 
 bool IPCFileEndpoint::WriteRaw(const void* pBuf, std::streamsize nBytes) {
   m_file.write((char*)pBuf, nBytes);
+  m_file.flush();
   if (m_file.bad())
     return false;
   return true;


### PR DESCRIPTION
We encountered some strange behavior whereby if our packets were too small, it bunched them together and sent in batches.

This was confirmed to resolve it, and is the proper fix rather than just making our payloads larger.