### PR TITLE
bump to v0.1.7

### DIFF
--- a/version.cmake
+++ b/version.cmake
@@ -1,1 +1,1 @@
-set(LeapIPC_VERSION 0.1.6)
+set(LeapIPC_VERSION 0.1.7)


### PR DESCRIPTION
We've found at least one bug affecting LMVP demos some time after we released v0.1.6, so unfortunately will have to do a small version update yet again.

At least now we have a bit more of the hang of things across the multiple build targets and their respective Docker containers.