### PR TITLE
Update autowiring and leapserial versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ matrix:
     - _CC: gcc-4.8
     - _CXX: g++-4.8
     - CMAKE_URL=http://cmake.org/files/v3.4/cmake-3.4.0-Linux-x86_64.tar.gz
-    - AUTOWIRING_URL=https://github.com/leapmotion/autowiring/releases/download/v1.0.4/autowiring-1.0.4-Linux-amd64.tar.gz
-    - LEAPSERIAL_URL=https://github.com/leapmotion/leapserial/releases/download/v0.5.0/LeapSerial-0.5.0-Linux-amd64.tar.gz
+    - AUTOWIRING_URL=https://github.com/leapmotion/autowiring/releases/download/v1.0.5/autowiring-1.0.5-Linux-amd64.tar.gz
+    - LEAPSERIAL_URL=https://github.com/leapmotion/leapserial/releases/download/v0.5.1/LeapSerial-0.5.1-Linux-amd64.tar.gz
     - CMAKE_DIRNAME=cmake-3.4.0-Linux-x86_64
     addons:
       apt:
@@ -25,8 +25,8 @@ matrix:
     - _CC: clang
     - _CXX: clang++
     - CMAKE_URL=http://cmake.org/files/v3.4/cmake-3.4.0-Darwin-x86_64.tar.gz
-    - AUTOWIRING_URL=https://github.com/leapmotion/autowiring/releases/download/v1.0.4/autowiring-1.0.4-Darwin.tar.gz
-    - LEAPSERIAL_URL=https://github.com/leapmotion/leapserial/releases/download/v0.5.0/LeapSerial-0.5.0-Darwin.tar.gz
+    - AUTOWIRING_URL=https://github.com/leapmotion/autowiring/releases/download/v1.0.5/autowiring-1.0.5-Darwin.tar.gz
+    - LEAPSERIAL_URL=https://github.com/leapmotion/leapserial/releases/download/v0.5.1/LeapSerial-0.5.1-Darwin.tar.gz
     - CMAKE_DIRNAME=cmake-3.4.0-Darwin-x86_64/CMake.app/Contents
     addons:
       apt:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(AddPCH)
 include(ConditionalSources)
 
 # All typically required packages
-find_package(autowiring 1.0.4 REQUIRED)
+find_package(autowiring 1.0.5 REQUIRED)
 find_package(leapserial 0.5.0 REQUIRED)
 
 # We have unit test projects via googletest, they're added in the places where they are defined

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ include(ConditionalSources)
 
 # All typically required packages
 find_package(autowiring 1.0.5 REQUIRED)
-find_package(leapserial 0.5.0 REQUIRED)
+find_package(leapserial 0.5.1 REQUIRED)
 
 # We have unit test projects via googletest, they're added in the places where they are defined
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ include(AddPCH)
 include(ConditionalSources)
 
 # All typically required packages
-find_package(autowiring 1.0.5 REQUIRED)
-find_package(leapserial 0.5.1 REQUIRED)
+find_package(autowiring 1.0.5 EXACT REQUIRED)
+find_package(leapserial 0.5.1 EXACT REQUIRED)
 
 # We have unit test projects via googletest, they're added in the places where they are defined
 enable_testing()


### PR DESCRIPTION
It's safest for LeapIPC to absorb all of Autowiring's bugfixes.

Also adding the `EXACT` keyword for these dependencies. While in theory this could run with autowiring 1.0.4, if we don't use the `EXACT` keyword it's hard to know if we're testing the right thing.