### PR TITLE
Remove usage of std::tr1 namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(autowiring 1.0.5 EXACT REQUIRED)
 find_package(leapserial 0.5.1 EXACT REQUIRED)
 
 # We have unit test projects via googletest, they're added in the places where they are defined
+add_definitions(-DGTEST_HAS_TR1_TUPLE=0)
 enable_testing()
 
 # Recurse through source directories


### PR DESCRIPTION
Needed here as well to adhere to deprecation in Visual Studio 2017 version 15.5