### PR TITLE
Update autowiring dependency to 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - _CC: gcc-4.8
     - _CXX: g++-4.8
     - CMAKE_URL=http://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.tar.gz
-    - AUTOWIRING_URL=https://github.com/leapmotion/autowiring/releases/download/v1.0.6/autowiring-1.0.6-Linux-amd64.tar.gz
+    - AUTOWIRING_URL=https://github.com/leapmotion/autowiring/releases/download/v1.1.0/autowiring-1.1.0-Linux-amd64.tar.gz
     - LEAPSERIAL_URL=https://github.com/leapmotion/leapserial/releases/download/v0.5.1/LeapSerial-0.5.1-Linux-amd64.tar.gz
     - CMAKE_DIRNAME=cmake-3.8.2-Linux-x86_64
     addons:
@@ -25,7 +25,7 @@ matrix:
     - _CC: clang
     - _CXX: clang++
     - CMAKE_URL=http://cmake.org/files/v3.8/cmake-3.8.2-Darwin-x86_64.tar.gz
-    - AUTOWIRING_URL=https://github.com/leapmotion/autowiring/releases/download/v1.0.6/autowiring-1.0.6-Darwin.tar.gz
+    - AUTOWIRING_URL=https://github.com/leapmotion/autowiring/releases/download/v1.1.0/autowiring-1.1.0-Darwin.tar.gz
     - LEAPSERIAL_URL=https://github.com/leapmotion/leapserial/releases/download/v0.5.1/LeapSerial-0.5.1-Darwin.tar.gz
     - CMAKE_DIRNAME=cmake-3.8.2-Darwin-x86_64/CMake.app/Contents
     addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - _CC: gcc-4.8
     - _CXX: g++-4.8
     - CMAKE_URL=http://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.tar.gz
-    - AUTOWIRING_URL=https://github.com/leapmotion/autowiring/releases/download/v1.0.5/autowiring-1.0.5-Linux-amd64.tar.gz
+    - AUTOWIRING_URL=https://github.com/leapmotion/autowiring/releases/download/v1.0.6/autowiring-1.0.6-Linux-amd64.tar.gz
     - LEAPSERIAL_URL=https://github.com/leapmotion/leapserial/releases/download/v0.5.1/LeapSerial-0.5.1-Linux-amd64.tar.gz
     - CMAKE_DIRNAME=cmake-3.8.2-Linux-x86_64
     addons:
@@ -25,7 +25,7 @@ matrix:
     - _CC: clang
     - _CXX: clang++
     - CMAKE_URL=http://cmake.org/files/v3.8/cmake-3.8.2-Darwin-x86_64.tar.gz
-    - AUTOWIRING_URL=https://github.com/leapmotion/autowiring/releases/download/v1.0.5/autowiring-1.0.5-Darwin.tar.gz
+    - AUTOWIRING_URL=https://github.com/leapmotion/autowiring/releases/download/v1.0.6/autowiring-1.0.6-Darwin.tar.gz
     - LEAPSERIAL_URL=https://github.com/leapmotion/leapserial/releases/download/v0.5.1/LeapSerial-0.5.1-Darwin.tar.gz
     - CMAKE_DIRNAME=cmake-3.8.2-Darwin-x86_64/CMake.app/Contents
     addons:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(AddPCH)
 include(ConditionalSources)
 
 # All typically required packages
-find_package(autowiring 1.0.6 EXACT REQUIRED)
+find_package(autowiring 1.1.0 EXACT REQUIRED)
 find_package(leapserial 0.5.1 EXACT REQUIRED)
 
 # We have unit test projects via googletest, they're added in the places where they are defined

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(AddPCH)
 include(ConditionalSources)
 
 # All typically required packages
-find_package(autowiring 1.0.5 EXACT REQUIRED)
+find_package(autowiring 1.0.6 EXACT REQUIRED)
 find_package(leapserial 0.5.1 EXACT REQUIRED)
 
 # We have unit test projects via googletest, they're added in the places where they are defined


### PR DESCRIPTION
Now that autowiring-1.1.0 has been released, update this for maintenance as well as secondary validation of autowiring-1.1.0